### PR TITLE
"constructor" should be translated into "コンストラクター"

### DIFF
--- a/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
+++ b/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
@@ -54,18 +54,18 @@
       <Docs>
         <summary><see cref="T:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException" /> クラスの新しいインスタンスを初期化します。</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- このコンス トラクターの初期化、 <xref:System.Exception.Message%2A> "defaultmessagedisplayedbyparameterlessctorwritermustsupply"このメッセージ、エラーを説明するシステム提供のメッセージの新しいインスタンスのプロパティでは、現在のシステムを考慮に入れますカルチャ。  
-  
- <xref:System.InsufficientMemoryException> のインスタンスの初期プロパティ値を次の表に示します。  
-  
-|プロパティ|[値]|  
-|--------------|-----------|  
-|<xref:System.Exception.InnerException%2A>|`null`。|  
-|<xref:System.Exception.Message%2A>|ローカライズされたエラー メッセージ文字列。|  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ このコンス トラクターの初期化、 <xref:System.Exception.Message%2A> "defaultmessagedisplayedbyparameterlessctorwritermustsupply"このメッセージ、エラーを説明するシステム提供のメッセージの新しいインスタンスのプロパティでは、現在のシステムを考慮に入れますカルチャ。
+
+ <xref:System.InsufficientMemoryException> のインスタンスの初期プロパティ値を次の表に示します。
+
+|プロパティ|[値]|
+|--------------|-----------|
+|<xref:System.Exception.InnerException%2A>|`null`。|
+|<xref:System.Exception.Message%2A>|ローカライズされたエラー メッセージ文字列。|
+
  ]]></format>
         </remarks>
       </Docs>
@@ -95,16 +95,16 @@
         <param name="message">例外の原因を説明するエラー メッセージ。</param>
         <summary><see cref="T:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException" /> クラスの新しいインスタンスを初期化します。</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- <xref:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException> のインスタンスの初期プロパティ値を次の表に示します。  
-  
-|プロパティ|[値]|  
-|--------------|-----------|  
-|<xref:System.Exception.InnerException%2A>|`null`。|  
-|<xref:System.Exception.Message%2A>|`message` に指定されたエラー メッセージ文字列。|  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ <xref:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException> のインスタンスの初期プロパティ値を次の表に示します。
+
+|プロパティ|[値]|
+|--------------|-----------|
+|<xref:System.Exception.InnerException%2A>|`null`。|
+|<xref:System.Exception.Message%2A>|`message` に指定されたエラー メッセージ文字列。|
+
  ]]></format>
         </remarks>
       </Docs>
@@ -131,11 +131,11 @@
         <param name="context">転送元または転送先についてのコンテキスト情報を含む <see cref="T:System.Runtime.Serialization.StreamingContext" /> です。</param>
         <summary><see cref="T:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException" /> クラスの新しいインスタンスを初期化します。</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- このコンストラクターは、逆シリアル化中に、ストリームで送信された例外オブジェクトを再構築するために呼び出されます。 詳細については、次を参照してください。 [XML および SOAP シリアル化](~/docs/standard/serialization/xml-and-soap-serialization.md)します。  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ このコンストラクターは、逆シリアル化中に、ストリームで送信された例外オブジェクトを再構築するために呼び出されます。 詳細については、次を参照してください。 [XML および SOAP シリアル化](~/docs/standard/serialization/xml-and-soap-serialization.md)します。
+
  ]]></format>
         </remarks>
         <related type="Article" href="~/docs/standard/serialization/xml-and-soap-serialization.md">XML シリアル化および SOAP シリアル化</related>
@@ -168,18 +168,18 @@
         <param name="innerException">エラー コード。 このパラメーターは null 参照 (<see langword="Nothing" />) でもかまいません。</param>
         <summary><see cref="T:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException" /> クラスの新しいインスタンスを初期化します。</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- 前の例外の直接の結果としてスローされる例外については、<xref:System.Exception.InnerException%2A> プロパティに、前の例外への参照が格納されます。 <xref:System.Exception.InnerException%2A> プロパティは、コンストラクターに渡されたものと同じ値を返します。`null` プロパティによって内部例外値がコンストラクターに渡されなかった場合は、<xref:System.Exception.InnerException%2A> を返します。  
-  
- <xref:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException> のインスタンスの初期プロパティ値を次の表に示します。  
-  
-|プロパティ|[値]|  
-|--------------|-----------|  
-|<xref:System.Exception.InnerException%2A>|`null`。|  
-|<xref:System.Exception.Message%2A>|`message` に指定されたエラー メッセージ文字列。|  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ 前の例外の直接の結果としてスローされる例外については、<xref:System.Exception.InnerException%2A> プロパティに、前の例外への参照が格納されます。 <xref:System.Exception.InnerException%2A> プロパティは、コンストラクターに渡されたものと同じ値を返します。`null` プロパティによって内部例外値がコンストラクターに渡されなかった場合は、<xref:System.Exception.InnerException%2A> を返します。
+
+ <xref:Microsoft.Build.BuildEngine.InvalidToolsetDefinitionException> のインスタンスの初期プロパティ値を次の表に示します。
+
+|プロパティ|[値]|
+|--------------|-----------|
+|<xref:System.Exception.InnerException%2A>|`null`。|
+|<xref:System.Exception.Message%2A>|`message` に指定されたエラー メッセージ文字列。|
+
  ]]></format>
         </remarks>
         <related type="Article" href="~/docs/standard/exceptions/index.md">例外の処理とスロー</related>
@@ -297,11 +297,11 @@
         <param name="context">転送元または転送先についてのコンテキスト情報を含む <see cref="T:System.Runtime.Serialization.StreamingContext" /> です。</param>
         <summary>例外に関する情報を含む <see cref="T:System.Runtime.Serialization.SerializationInfo" /> を設定します。</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- このコンストラクターは、逆シリアル化中に、ストリームで送信された例外オブジェクトを再構築するために呼び出されます。 詳細については、次を参照してください。 [XML および SOAP シリアル化](~/docs/standard/serialization/xml-and-soap-serialization.md)します。  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ このコンストラクターは、逆シリアル化中に、ストリームで送信された例外オブジェクトを再構築するために呼び出されます。 詳細については、次を参照してください。 [XML および SOAP シリアル化](~/docs/standard/serialization/xml-and-soap-serialization.md)します。
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
+++ b/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
@@ -57,7 +57,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- このコンス トラクターの初期化、 <xref:System.Exception.Message%2A> "defaultmessagedisplayedbyparameterlessctorwritermustsupply"このメッセージ、エラーを説明するシステム提供のメッセージの新しいインスタンスのプロパティでは、現在のシステムを考慮に入れますカルチャ。
+ このコンストラクターの初期化、 <xref:System.Exception.Message%2A> "defaultmessagedisplayedbyparameterlessctorwritermustsupply"このメッセージ、エラーを説明するシステム提供のメッセージの新しいインスタンスのプロパティでは、現在のシステムを考慮に入れますカルチャ。
 
  <xref:System.InsufficientMemoryException> のインスタンスの初期プロパティ値を次の表に示します。
 

--- a/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
+++ b/xml/Microsoft.Build.BuildEngine/InvalidToolsetDefinitionException.xml
@@ -57,7 +57,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- このコンストラクターの初期化、 <xref:System.Exception.Message%2A> "defaultmessagedisplayedbyparameterlessctorwritermustsupply"このメッセージ、エラーを説明するシステム提供のメッセージの新しいインスタンスのプロパティでは、現在のシステムを考慮に入れますカルチャ。
+ このコンストラクターは、新しいインスタンスの Message プロパティを、"defaultmessagedisplayedbyparameterlessctorwritermustsupply"のように、エラーを説明するシステム提供のメッセージに初期化します。このメッセージは、現在のシステム カルチャを考慮します。
 
  <xref:System.InsufficientMemoryException> のインスタンスの初期プロパティ値を次の表に示します。
 


### PR DESCRIPTION
"constructor" is mistranslated into "コンス\s+トラクター", but should be translated into "コンストラクター". It looks odd just like "cons tructor".

I fixed one file to create this PR, but 7431 other occurences in 2265 files left. You should write some script or fix your dictionary.