### PR TITLE
fix wrong translation to Japanese

### DIFF
--- a/xml/System.Collections.Generic/Dictionary`2.xml
+++ b/xml/System.Collections.Generic/Dictionary`2.xml
@@ -119,9 +119,9 @@
    
   
 ## Examples  
- 次のコード例は、空を作成します。<xref:System.Collections.Generic.Dictionary%602>文字列を使用して文字列のキーの、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドをいくつかの要素を追加します。 例を示しますが、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドがスローされます、<xref:System.ArgumentException>重複するキーを追加しようとしています。  
+ 次のコード例は、TKey型としてstring、TValue型としてstringを持つ<xref:System.Collections.Generic.Dictionary%602>型の空のインスタンスを生成して、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドを使っていくつかの要素を追加します。 例では重複するキーを追加しようとしたとき、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドが、例外<xref:System.ArgumentException>を投げることを示しています。  
   
- この例では、<xref:System.Collections.Generic.Dictionary%602.Item%2A>プロパティ (c# のインデクサー) を示す値を取得する、<xref:System.Collections.Generic.KeyNotFoundException>要求されたキーが存在しないと置き換えることができます、値がキーに関連付けられていることを示す場合にスローされます。  
+ この例では値を取得するために<xref:System.Collections.Generic.Dictionary%602.Item%2A>プロパティ (c# のインデクサー) を使用して、要求されたキーが存在しない場合には例外<xref:System.Collections.Generic.KeyNotFoundException>が投げられることとキーと関連付けされた値を置き換えることができることを示しています。  
   
  例を使用する方法を示します、<xref:System.Collections.Generic.Dictionary%602.TryGetValue%2A>メソッド値を取得する場合は、プログラムは多くの場合、ディクショナリに含まれていないキーの値を試行する必要があり、使用する方法を示しますより効率的な方法として、 <xref:System.Collections.Generic.Dictionary%602.ContainsKey%2A> を呼び出す前に、キーが存在するかどうかをテストする方法を <xref:System.Collections.Generic.Dictionary%602.Add%2A> メソッドです。  
   

--- a/xml/System.Collections.Generic/Dictionary`2.xml
+++ b/xml/System.Collections.Generic/Dictionary`2.xml
@@ -121,7 +121,7 @@
 ## Examples  
  次のコード例は、TKey型としてstring、TValue型としてstringを持つ<xref:System.Collections.Generic.Dictionary%602>型の空のインスタンスを生成して、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドを使っていくつかの要素を追加します。 例では重複するキーを追加しようとしたとき、<xref:System.Collections.Generic.Dictionary%602.Add%2A>メソッドが、例外<xref:System.ArgumentException>を投げることを示しています。  
   
- この例では値を取得するために<xref:System.Collections.Generic.Dictionary%602.Item%2A>プロパティ (c# のインデクサー) を使用して、要求されたキーが存在しない場合には例外<xref:System.Collections.Generic.KeyNotFoundException>が投げられることとキーと関連付けされた値を置き換えることができることを示しています。  
+ この例では値を取得するために<xref:System.Collections.Generic.Dictionary%602.Item%2A>プロパティ (C# のインデクサー) を使用して、要求されたキーが存在しない場合には例外<xref:System.Collections.Generic.KeyNotFoundException>が投げられることとキーと関連付けされた値を置き換えることができることを示しています。
   
  例を使用する方法を示します、<xref:System.Collections.Generic.Dictionary%602.TryGetValue%2A>メソッド値を取得する場合は、プログラムは多くの場合、ディクショナリに含まれていないキーの値を試行する必要があり、使用する方法を示しますより効率的な方法として、 <xref:System.Collections.Generic.Dictionary%602.ContainsKey%2A> を呼び出す前に、キーが存在するかどうかをテストする方法を <xref:System.Collections.Generic.Dictionary%602.Add%2A> メソッドです。  
   


### PR DESCRIPTION
the translation may be wrong.
so i tried to rewrote that, partially.

(wrong translation ex.
 in English from wrong translation,  A example showing that Add method is thrown and ArgumentException will add duplicated keys.

Sorry i do Not know how to check in markdown viewer.
So the translation was unchecked by view mode in markdown. 