### PR TITLE
JsonSerializerOptionsのリンク切れの修正と文言修正

### DIFF
--- a/xml/System.Text.Json/JsonSerializerOptions.xml
+++ b/xml/System.Text.Json/JsonSerializerOptions.xml
@@ -146,7 +146,7 @@
       </ReturnValue>
       <Docs>
         <summary><see cref="T:System.Collections.IDictionary" /> キーの名前を、camel 形式などの別の形式に変換するために使用されるポリシーを取得または設定します。</summary>
-        <value>@No__t 0 のキーの名前を別の形式に変換するために使用するポリシー。</value>
+        <value><see cref="T:System.Collections.IDictionary" /> のキーの名前を別の形式に変換するために使用するポリシー。</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -285,7 +285,7 @@
 
 ## Remarks
 
-この深さを超えると、@no__t 0 がスローされます。
+この深さを超えると、<xref:System.Text.Json.JsonException> がスローされます。
 
           ]]></format>
         </remarks>
@@ -347,7 +347,7 @@
 
 結果として得られるプロパティ名は、逆シリアル化時に JSON ペイロードに一致すると予測され、シリアル化中にプロパティ名を書き込むときに使用されます。
 
-このポリシーは、@no__t 0 が適用されているプロパティには使用されません。
+このポリシーは、<xref:System.Text.Json.Serialization.JsonPropertyNameAttribute> が適用されているプロパティには使用されません。
 
 このプロパティを <xref:System.Text.Json.JsonNamingPolicy.CamelCase?displayProperty=nameWithType> に設定すると、camel 形式のポリシーを指定できます。
 
@@ -403,7 +403,7 @@
       </ReturnValue>
       <Docs>
         <summary>JSON で整形出力を使用する必要があるかどうかを定義する値を取得または設定します。 既定では、JSON は余分な空白なしでシリアル化されます。</summary>
-        <value>@no__t-JSON がシリアル化に対して非常に印刷される場合は0。それ以外の場合は、<see langword="false" /> です。 既定値は、<see langword="false" /> です。</value>
+        <value>JSON がシリアル化に対して整形出力される場合は<see langword="true" /> 。それ以外の場合は、<see langword="false" /> です。 既定値は、<see langword="false" /> です。</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
 


### PR DESCRIPTION
Link切れを起こしていた箇所が見つかったため
https://github.com/dotnet/dotnet-api-docs/blob/5ff40cc0a871754e525b5430463a0b821d31c4fb/xml/System.Text.Json/JsonSerializerOptions.xml
を参考にリンクを追加しました。

また翻訳の揺れが修正箇所付近に見つかったため
https://github.com/dotnet/dotnet-api-docs.ja-jp/compare/live...yamachu:fix/broken-links?expand=1#diff-ec7fff5850277b7d650afa9d46b472d3R406
併せて修正を行いました。