### PR TITLE
算用数字で10,000が漢数字1万に過剰に訳されている

### DIFF
--- a/xml/System/TimeSpan.xml
+++ b/xml/System/TimeSpan.xml
@@ -3752,7 +3752,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- この定数の値は1万です。つまり、1万です。  
+ この定数の値は1万です。つまり、10,000です。  
   
    
   


### PR DESCRIPTION
元: The value of this constant is 10 thousand; that is, 10,000.

日本語としては「つまり」以下不要かも。